### PR TITLE
Fix: Add src/Subscriber and README

### DIFF
--- a/src/api/README.md
+++ b/src/api/README.md
@@ -12,6 +12,8 @@ export default () => {
       message: "Welcome to Medusa!"
     })
   })
+
+  return router;
 }
 ```
 
@@ -31,5 +33,7 @@ export default () => {
       message: `Welcome to ${product.title}!`
     })
   })
+
+  return router;
 }
 ```

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -20,6 +20,8 @@ class MyService extends BaseService {
     return `Welcome to ${product.title}!`
   }
 }
+
+export default MyService;
 ```
 
 The first argument to the `constructor` is the global giving you access to easy dependency injection. The container holds all registered services from the core, installed plugins and from other files in the `/services` directory. The registration name is a camelCased version of the file name with the type appended i.e.: `my.js` is registered as `myService`, `custom-thing.js` is registerd as `customThingService`.
@@ -39,5 +41,7 @@ export default () => {
       message: await myService.getProductMessage()
     })
   })
+
+  return router;
 }
 ```

--- a/src/subscribers/README.md
+++ b/src/subscribers/README.md
@@ -1,0 +1,26 @@
+# Custom subscribers
+
+You may define custom eventhandlers, `subscribers` by creating files in the `/subscribers` directory. 
+
+```js
+class WelcomeSubscriber {
+  constructor({ welcomeService, eventBusService }) {
+    this.welcomeService_ = welcomeService;
+
+    eventBusService.subscribe("order.placed", this.handleWelcome);
+  }
+
+  handleWelcome = async (data) => {
+    return await this.welcomeService_.sendWelcome(data.id);
+  };
+}
+
+export default WelcomeSubscriber;
+```
+
+A subscriber is defined as a `class` which is registered as a subscriber by invoking `eventBusService.subscribe` in the `constructor` of the class.
+
+The type of event that the subscriber subscribes to is passed as the first parameter to the `eventBusService.subscribe` and the eventhandler is passed as the second parameter. The types of events a service can emmit are described in the individual service.
+
+An eventhandler has one paramenter; a data `object` with only an `id` field. The `id` can be used to fetch the appropriate entity in the eventhandler.
+

--- a/src/subscribers/README.md
+++ b/src/subscribers/README.md
@@ -1,6 +1,6 @@
 # Custom subscribers
 
-You may define custom eventhandlers, `subscribers` by creating files in the `/subscribers` directory. 
+You may define custom eventhandlers, `subscribers` by creating files in the `/subscribers` directory.
 
 ```js
 class WelcomeSubscriber {
@@ -22,5 +22,4 @@ A subscriber is defined as a `class` which is registered as a subscriber by invo
 
 The type of event that the subscriber subscribes to is passed as the first parameter to the `eventBusService.subscribe` and the eventhandler is passed as the second parameter. The types of events a service can emmit are described in the individual service.
 
-An eventhandler has one paramenter; a data `object` with only an `id` field. The `id` can be used to fetch the appropriate entity in the eventhandler.
-
+An eventhandler has one paramenter; a data `object` wich contain information relating to the event, including relevant `id's`. The `id` can be used to fetch the appropriate entity in the eventhandler.

--- a/src/subscribers/README.md
+++ b/src/subscribers/README.md
@@ -22,4 +22,4 @@ A subscriber is defined as a `class` which is registered as a subscriber by invo
 
 The type of event that the subscriber subscribes to is passed as the first parameter to the `eventBusService.subscribe` and the eventhandler is passed as the second parameter. The types of events a service can emmit are described in the individual service.
 
-An eventhandler has one paramenter; a data `object` wich contain information relating to the event, including relevant `id's`. The `id` can be used to fetch the appropriate entity in the eventhandler.
+An eventhandler has one paramenter; a data `object` which contain information relating to the event, including relevant `id's`. The `id` can be used to fetch the appropriate entity in the eventhandler.


### PR DESCRIPTION
**What?**
- Added `/src/subscribers` to the template
- Added `export` statement to the service README
- Added `return` statement to the api README

**Why?**
- Congruency with the quickstart guide
- Show complete methods for service creation and api creation