### PR TITLE
Feat/docker compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:17.1.0
+
+WORKDIR /app/medusa
+
+COPY package.json .
+
+RUN apt-get update
+
+RUN apt-get install -y python
+
+RUN npm install -g npm@latest
+
+RUN npm install -g @medusajs/medusa-cli
+
+COPY . .
+
+ENTRYPOINT ["./develop.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,16 @@ FROM node:17.1.0
 
 WORKDIR /app/medusa
 
-COPY . .
-
-RUN rm -rf node_modules
+COPY package.json .
+COPY develop.sh .
+COPY yarn.lock .
 
 RUN apt-get update
 
 RUN apt-get install -y python
 
-RUN npm install -g npm@latest
+RUN yarn global add @medusajs/medusa-cli
 
-RUN npm install -g @medusajs/medusa-cli
-
-RUN npm install
+RUN yarn install
 
 ENTRYPOINT ["./develop.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get install -y python
 
 RUN npm install -g npm@latest
 
-RUN npm install -g @medusajs/medusa-cli
+RUN npm install -g @medusajs/medusa-cli@latest
 
 RUN npm install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM node:17.1.0
 
 WORKDIR /app/medusa
 
-COPY package.json .
+COPY . .
+
+RUN rm -rf node_modules
 
 RUN apt-get update
 
@@ -12,6 +14,6 @@ RUN npm install -g npm@latest
 
 RUN npm install -g @medusajs/medusa-cli
 
-COPY . .
+RUN npm install
 
 ENTRYPOINT ["./develop.sh"]

--- a/README.md
+++ b/README.md
@@ -53,9 +53,13 @@ Your local Medusa server is now running on port **9000**.
 
 ## Setting up your store with docker and postgres
 
+- Install the Medusa CLI
+  ```
+  npm install -g @medusajs/medusa-cli
+  ```
 - Create a new Medusa project
   ```
-  git clone https://https://github.com/medusajs/medusa-starter-default.git
+  medusa new my-medusa-store
   ```
 - Update your medusa config:
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ This starter has minimal prerequisites and most of these will usually already be
 
 Your local Medusa server is now running on port **9000**.
 
+### Seeding your Medusa store
+
+---
+
+To add seed data to your medusa store run the following command:
+
+```
+medusa seed -f ./data/seed.json
+```
+
+This command adds seed data to your database, including a store, an administrator account, a region and a product with variants. What the data looks like precisely you can see in the `./data/seed.json` file.
+
 ## Setting up your store with Docker
 
 - Install the Medusa CLI
@@ -61,17 +73,14 @@ Your local Medusa server is now running on port **9000**.
   ```
   medusa new my-medusa-store
   ```
-- Update your medusa config:
+- Update project config in `medusa-config.js`:
 
   ```
   module.exports = {
     projectConfig: {
       redis_url: REDIS_URL,
-      // For more production-like environment install PostgresQL
-      database_url: DATABASE_URL,
+      database_url: DATABASE_URL, //postgres connectionstring
       database_type: "postgres",
-      // database_database: "./medusa-db.sql",
-      // database_type: "sqlite",
       store_cors: STORE_CORS,
       admin_cors: ADMIN_CORS,
     },
@@ -94,6 +103,18 @@ Your local Medusa server is now running on port **9000**.
   ```
 
 Your local Medusa server is now running on port **9000**.
+
+### Seeding your Medusa store with Docker
+
+---
+
+To add seed data to your medusa store runnign with Docker, run this command in a seperate terminal:
+
+```
+docker exec medusa-server medusa seed -f ./data/seed.json
+```
+
+This will execute the same seed script as described above in the `medusa-server` Docker container.
 
 ## Try it out
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,15 @@ This repo provides the skeleton to get you started with using <a href="https://g
 </p>
 
 ## Prerequisites
+
 This starter has minimal prerequisites and most of these will usually already be installed on your computer.
 
 - [Install Node.js](https://nodejs.org/en/download/)
 - [Install git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [Install SQLite](https://www.sqlite.org/download.html)
 
-## Setting up your store
+## Setting up your store SQLite
+
 - Install the Medusa CLI
   ```
   npm install -g @medusajs/medusa
@@ -47,7 +49,38 @@ This starter has minimal prerequisites and most of these will usually already be
   medusa develop
   ```
 
-Your local Medusa server is now running on port **9000**. 
+Your local Medusa server is now running on port **9000**.
+
+## Setting up your store with docker
+
+- Create a new Medusa project
+  ```
+  git clone https://https://github.com/medusajs/medusa-starter-default.git
+  ```
+- Modify your medusa config:
+
+  ```
+  module.exports = {
+    projectConfig: {
+      redis_url: REDIS_URL,
+      // For more production-like environment install PostgresQL
+      database_url: DATABASE_URL,
+      database_type: "postgres",
+      // database_database: "./medusa-db.sql",
+      // database_type: "sqlite",
+      store_cors: STORE_CORS,
+      admin_cors: ADMIN_CORS,
+    },
+    plugins,
+  };
+  ```
+
+- Run your project
+  ```
+  docker compose up
+  ```
+
+Your local Medusa server is now running on port **9000**.
 
 ## Try it out
 
@@ -61,7 +94,6 @@ After the seed script has run you will have the following things in you database
 - a Region called Default Region with the countries GB, DE, DK, SE, FR, ES, IT
 - a Shipping Option called Standard Shipping which costs 10 EUR
 - a Product called Cool Test Product with 4 Product Variants that all cost 19.50 EUR
-
 
 Visit [docs.medusa-commerce.com](https://docs.medusa-comerce.com) for further guides.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This starter has minimal prerequisites and most of these will usually already be
 
 Your local Medusa server is now running on port **9000**.
 
-## Setting up your store with docker
+## Setting up your store with docker and postgres
 
 - Create a new Medusa project
   ```
@@ -76,6 +76,15 @@ Your local Medusa server is now running on port **9000**.
   ```
 
 - Run your project
+
+  When running your project the first time `docker compose` should be run with the `build` flag to build your contianer locally:
+
+  ```
+  docker compose up --build
+  ```
+
+  When running your project subsequent times you can run docker compose with no flags to spin up your local environment in seconds:
+
   ```
   docker compose up
   ```

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ Your local Medusa server is now running on port **9000**.
 
 ---
 
-To add seed data to your medusa store run the following command:
+To seed your medusa store run the following command:
 
 ```
 medusa seed -f ./data/seed.json
 ```
 
-This command adds seed data to your database, including a store, an administrator account, a region and a product with variants. What the data looks like precisely you can see in the `./data/seed.json` file.
+This command seeds your database with some sample datal to get you started, including a store, an administrator account, a region and a product with variants. What the data looks like precisely you can see in the `./data/seed.json` file.
 
 ## Setting up your store with Docker
 
@@ -114,7 +114,7 @@ To add seed data to your medusa store runnign with Docker, run this command in a
 docker exec medusa-server medusa seed -f ./data/seed.json
 ```
 
-This will execute the same seed script as described above in the `medusa-server` Docker container.
+This will execute the previously described seed script in the running `medusa-server` Docker container.
 
 ## Try it out
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This starter has minimal prerequisites and most of these will usually already be
 - [Install git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - [Install SQLite](https://www.sqlite.org/download.html)
 
-## Setting up your store SQLite
+## Setting up your store
 
 - Install the Medusa CLI
   ```
@@ -51,7 +51,7 @@ This starter has minimal prerequisites and most of these will usually already be
 
 Your local Medusa server is now running on port **9000**.
 
-## Setting up your store with docker and postgres
+## Setting up your store with Docker
 
 - Create a new Medusa project
   ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Your local Medusa server is now running on port **9000**.
   ```
   git clone https://https://github.com/medusajs/medusa-starter-default.git
   ```
-- Modify your medusa config:
+- Update your medusa config:
 
   ```
   module.exports = {

--- a/develop.sh
+++ b/develop.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#Install packages
+npm install --loglevel=error
+
+#Run migrations to ensure the database is updated
+medusa migrations run
+
+#Start development environment
+medusa develop

--- a/develop.sh
+++ b/develop.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-#Install packages
-npm install --loglevel=error
-
 #Run migrations to ensure the database is updated
 medusa migrations run
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.8"
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: backend:test
+    container_name: medusa-server-default
+    depends_on:
+      - postgres
+      - redis
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@postgres:5432/medusa-docker
+      REDIS_URL: redis://medusa-cache
+      NODE_ENV: development
+      PORT: 9000
+    ports:
+      - "9000:9000"
+    volumes:
+      - .:/app/medusa
+
+  postgres:
+    image: postgres:10.4
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: medusa-docker
+
+  redis:
+    image: redis
+    container_name: medusa-cache
+    expose:
+      - 6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - "9000:9000"
     volumes:
       - .:/app/medusa
+      - node_modules:/app/medusa/node_modules
 
   postgres:
     image: postgres:10.4
@@ -33,3 +34,6 @@ services:
     container_name: medusa-cache
     expose:
       - 6379
+
+volumes:
+  node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,17 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: backend:test
+    image: backend:starter
     container_name: medusa-server-default
     depends_on:
       - postgres
       - redis
     environment:
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/medusa-docker
-      REDIS_URL: redis://medusa-cache
+      REDIS_URL: redis://redis
       NODE_ENV: development
+      JWT_SECRET: something
+      COOKIE_SECRET: something
       PORT: 9000
     ports:
       - "9000:9000"
@@ -31,7 +33,6 @@ services:
 
   redis:
     image: redis
-    container_name: medusa-cache
     expose:
       - 6379
 

--- a/medusa-config.js
+++ b/medusa-config.js
@@ -32,12 +32,12 @@ const plugins = [
 
 module.exports = {
   projectConfig: {
-    // redis_url: REDIS_URL,
+    redis_url: REDIS_URL,
     // For more production-like environment install PostgresQL
-    // database_url: DATABASE_URL,
-    // database_type: "postgres",
-    database_database: "./medusa-db.sql",
-    database_type: "sqlite",
+    database_url: DATABASE_URL,
+    database_type: "postgres",
+    // database_database: "./medusa-db.sql",
+    // database_type: "sqlite",
     store_cors: STORE_CORS,
     admin_cors: ADMIN_CORS,
   },

--- a/medusa-config.js
+++ b/medusa-config.js
@@ -32,12 +32,12 @@ const plugins = [
 
 module.exports = {
   projectConfig: {
-    redis_url: REDIS_URL,
+    // redis_url: REDIS_URL,
     // For more production-like environment install PostgresQL
-    database_url: DATABASE_URL,
-    database_type: "postgres",
-    // database_database: "./medusa-db.sql",
-    // database_type: "sqlite",
+    // database_url: DATABASE_URL,
+    // database_type: "postgres",
+    database_database: "./medusa-db.sql",
+    database_type: "sqlite",
     store_cors: STORE_CORS,
     admin_cors: ADMIN_CORS,
   },


### PR DESCRIPTION
**What**
- docker compose for easy setup of a local medusa server

**Why**
- to help people get started easily without local installations

**How**
- Create `Dockerfile` describing how to build the image
- Create `docker-compose.yml` describing how to deploy postgres, redis and the backend for local development

**Testing**
- running docker-compose from a fresh install

To test the docker setup yourself run: `docker compose up --build` to build the docker images, this is only needed the first time and is done implicitly if you dont pass the `--build` flag to `docker compose`. 