### PR TITLE
feat: Add docker compose settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 /uploads
 /node_modules
 yarn-error.log
-
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:16
+
+WORKDIR /usr/src/app
+
+RUN npm install -g @medusajs/medusa-cli
+COPY package*.json ./
+
+RUN npm install
+
+EXPOSE 9000
+
+CMD [ "/bin/bash", "./entrypoint.sh" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.8'
+
+services:
+  database:
+    image: 'postgres:latest'
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: username
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: medusa-store
+  redis:
+    image: redis:latest
+    ports:
+      - 6379:6379
+  medusa:
+    build: .
+    depends_on:
+      - database
+      - redis
+    working_dir: /usr/src/app
+    volumes:
+      - ./:/usr/src/app
+      - /usr/src/app/node_modules
+    ports:
+      - 9000:9000
+    environment:
+      DATABASE_URL: postgresql://username:password@database/medusa-store
+      REDIS_URL: redis://redis:6379
+    env_file: .env
+    links:
+      - database
+      - redis

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+medusa migrations run
+medusa develop

--- a/medusa-config.js
+++ b/medusa-config.js
@@ -32,12 +32,12 @@ const plugins = [
 
 module.exports = {
   projectConfig: {
-    // redis_url: REDIS_URL,
+    redis_url: REDIS_URL,
     // For more production-like environment install PostgresQL
-    // database_url: DATABASE_URL,
-    // database_type: "postgres",
-    database_database: "./medusa-db.sql",
-    database_type: "sqlite",
+    database_url: DATABASE_URL,
+    database_type: "postgres",
+    // database_database: "./medusa-db.sql",
+    // database_type: "sqlite",
     store_cors: STORE_CORS,
     admin_cors: ADMIN_CORS,
   },


### PR DESCRIPTION
Hi there, I've put together a `docker-compose` file that spins up Redis, Postgres and Medusa Starter. The main purpose is easing the steps to set up the development environment for medusa, so it uses a bind mount on the project's folder to apply any change on the source code immediately, without the need of recreating the docker image.