### PR TITLE
hotfix: Include port 7001 in admin cors

### DIFF
--- a/medusa-config.js
+++ b/medusa-config.js
@@ -1,5 +1,5 @@
 // CORS when consuming Medusa from admin
-const ADMIN_CORS = process.env.ADMIN_CORS || "http://localhost:7000";
+const ADMIN_CORS = process.env.ADMIN_CORS || "http://localhost:7000,http://localhost:7001";
 
 // CORS to avoid issues when consuming Medusa from a client
 const STORE_CORS = process.env.STORE_CORS || "http://localhost:8000";


### PR DESCRIPTION
Add port 7001 to `ADMIN_CORS`, since the new versions of MacOS occupy that port for some AirPlay functionality