### PR TITLE
fix: Dockerfile and add dockeringore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ RUN npm install -g @medusajs/medusa-cli@latest
 
 RUN npm install
 
+COPY . .
+
 ENTRYPOINT ["./develop.sh"]


### PR DESCRIPTION
**What**
- currently, `src` folder isn't copied during a build which is preventing the container from running properly (in a case where the Dockerfile image is built directly without the docker compose file)

**How**
- copy the rest of the project files after npm install layer
- add `.dockerignore`

**TODO**
 - [ ] docker build is failing if `yarn.lock` doesn't exist, which will happen if the user is using npm as the package manager
 
We should also consider changing the current Dockerfile to do a build of the project (which is expected from the main Dockerfile in the project), and do dev overrides in the `docker-compose.dev.yml`. Many hosting services will pick up Dockerfile and expect it to create a production build.