### PR TITLE
chore: fixed error of copying yarn.lock when it doesn't exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app/medusa
 
 COPY package.json .
 COPY develop.sh .
-COPY yarn.lock .
+COPY yarn.* .
 
 RUN apt-get update
 


### PR DESCRIPTION
When `yarn.lock` doesn't exist Docker setup fails. This PR fixes it by changing `yarn.lock` to `yarn.*` which optionally copies the file if it exists