### PR TITLE
Set the correct NPM version for node 17.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update
 
 RUN apt-get install -y python
 
-RUN npm install -g npm@latest
+RUN npm install -g npm@8.1.2
 
 RUN npm install -g @medusajs/medusa-cli@latest
 


### PR DESCRIPTION
Fix the npm version that we can install with node 17.1 
fix related to https://github.com/medusajs/medusa/issues/2636