### PR TITLE
fix: :green_heart: Fix the ports exposed by Redis in the docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,8 @@ services:
 
   redis:
     image: redis
-    expose:
-      - 6379
+    ports:
+      - "6379:6379"
 
 volumes:
   node_modules:


### PR DESCRIPTION
## Issue linked
https://github.com/medusajs/medusa-starter-default/issues/35

## Details

- Replaced `expose` by `ports` key