### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@medusajs/event-bus-local": "^1.9.4",
     "@medusajs/event-bus-redis": "^1.8.7",
     "@medusajs/file-local": "^1.0.1",
-    "@medusajs/medusa": "^1.12.0",
+    "@medusajs/medusa": "^1.13.0",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "dotenv": "^16.1.4",


### PR DESCRIPTION
The medusa-cli new command `medusa new` uses this repository as the default starter project, and it should always contain the latest version of medusa but it's package.json is still using medusa 1.12.0 so whenever someone create a new medusa project using the cli tool it will create a project using the older version of medusa, I updated it to use the latest version.