### PR TITLE
fix: remove yarn.lock and package-lock.json from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ coverage
 !src/**
 
 ./tsconfig.tsbuildinfo
-package-lock.json
-yarn.lock
 medusa-db.sql
 build
 .cache


### PR DESCRIPTION
## What

Removes `yarn.lock` and `package-lock.json` from `.gitignore`

## Why

During deployments, this can cause an error if the `yarn.lock` and `package-lock.json` are not committed as part of the repository. An example of that is when deploying to digitalocean which causes an error of no package manager being found.