### PR TITLE
chore: typo backendUrl default url

### DIFF
--- a/src/admin/components/onboarding-flow/default/products/product-detail.tsx
+++ b/src/admin/components/onboarding-flow/default/products/product-detail.tsx
@@ -16,7 +16,7 @@ const ProductDetailDefault = ({ onNext, isComplete, data }: StepContentProps) =>
   const api_key = useMemo(() => keys?.[0]?.id || "", [keys])
   const backendUrl = process.env.MEDUSA_BACKEND_URL === "/" || process.env.MEDUSA_ADMIN_BACKEND_URL === "/" ? 
     location.origin :
-    process.env.MEDUSA_BACKEND_URL || process.env.MEDUSA_ADMIN_BACKEND_URL || "http://location:9000"
+    process.env.MEDUSA_BACKEND_URL || process.env.MEDUSA_ADMIN_BACKEND_URL || "http://localhost:9000"
 
   useEffect(() => {
     if (!isLoading && !keys?.length) {


### PR DESCRIPTION
`http://location:9000` should be `http://localhost:9000`