### PR TITLE
turn off auto reload of admin page in production

### DIFF
--- a/medusa-config.js
+++ b/medusa-config.js
@@ -46,7 +46,7 @@ const plugins = [
     resolve: "@medusajs/admin",
     /** @type {import('@medusajs/admin').PluginOptions} */
     options: {
-      autoRebuild: true,
+      autoRebuild: process.env.NODE_ENV !== "production",
       develop: {
         open: process.env.OPEN_BROWSER !== "false",
       },


### PR DESCRIPTION
Some cloud providers don't use the same build machines in prod as dev, and in some cases don't cache the header files for SWC. This results in some deploys failing as the app tries to run webpack in prod which causes runtime failures.

Separately, running this causes more memory usage, which may make new developers believe their minimum requirements and thus spend in the cloud is higher than it actually needs to be. For example, you can run this on the free tier of some services such as render.com but couldn't if you are trying to run webpack on the deployed machine.