### PR TITLE
chore: add back @swc/core for development environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@mikro-orm/migrations": "5.9.7",
     "@mikro-orm/postgresql": "5.9.7",
     "@stdlib/number-float64-base-normalize": "0.0.8",
+    "@swc/core": "1.5.7",
     "@types/express": "^4.17.13",
     "@types/mime": "1.3.5",
     "@types/node": "^17.0.8",


### PR DESCRIPTION
SWC is needed to run the Dev server quickly. Otherwise, `ts-node` will end up using the official TypeScript compiler and takes ages to start the dev-server