### PR TITLE
fix: Add emailpass dependency directly to package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@medusajs/api-key": "preview",
     "@medusajs/auth": "preview",
+    "@medusajs/auth-emailpass": "preview",
     "@medusajs/cache-inmemory": "preview",
     "@medusajs/cart": "preview",
     "@medusajs/currency": "preview",
@@ -60,9 +61,9 @@
     "@types/mime": "1.3.5",
     "@types/node": "^17.0.8",
     "@types/react": "^18.3.2",
+    "prop-types": "^15.8.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.1.6",
-    "prop-types": "^15.8.1"
+    "typescript": "^5.1.6"
   },
   "resolutions": {
     "**/@medusajs/medusa-cli": "link:./node_modules/@medusajs/medusa-cli"

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,7 +758,7 @@
     "@mikro-orm/postgresql" "5.9.7"
     awilix "^8.0.0"
 
-"@medusajs/auth-emailpass@0.0.2-preview-20240812090517":
+"@medusajs/auth-emailpass@0.0.2-preview-20240812090517", "@medusajs/auth-emailpass@preview":
   version "0.0.2-preview-20240812090517"
   resolved "https://registry.yarnpkg.com/@medusajs/auth-emailpass/-/auth-emailpass-0.0.2-preview-20240812090517.tgz#bc60af0d1579323562ef6d87b04a020c546a9649"
   integrity sha512-WfOic0vIGIK1qsSTtQqP5BH8ivzuB2vOQRn639DF85igWRpHSYzFbsxT6O3brh2dgEBSr5QfX7PCh1p88mh+fA==


### PR DESCRIPTION
After https://github.com/medusajs/medusa/pull/8557 is merged, we'll need the dependency directly defined in the package json. We should merge this PR first.