### PR TITLE
Chore: prepare for subpath imports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "target": "es2019",
+    "target": "ES2021",
     "allowJs": true,
     "esModuleInterop": true,
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "skipLibCheck": true,


### PR DESCRIPTION
In order to use subpath exports from Node.js, we have to set the `moduleTarget` to `Node16`. Also, I have updated the output target to `ES2021`, since all the features of `ES2021` are natively support by Node.js

This change should not bring any breaking changes in the starter.