### PR TITLE
chore: install awilix as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "bignumber.js": "^9.1.2",
     "ioredis": "^5.4.1",
     "pg": "^8.13.0",
-    "awilix": "^11.0.0"
+    "awilix": "^8.0.1"
   },
   "devDependencies": {
     "vite": "^5.2.11",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "@mikro-orm/postgresql": "5.9.7",
     "bignumber.js": "^9.1.2",
     "ioredis": "^5.4.1",
-    "pg": "^8.13.0"
+    "pg": "^8.13.0",
+    "awilix": "^11.0.0"
   },
   "devDependencies": {
     "vite": "^5.2.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5198,6 +5198,14 @@ autoprefixer@^10.4.16:
     picocolors "^1.0.1"
     postcss-value-parser "^4.2.0"
 
+awilix@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/awilix/-/awilix-11.0.0.tgz#d2b654fd22e43d93ff1dc58285e13d468d04c122"
+  integrity sha512-lnEm2TZu1OUWO1twi/3JrjSYu3RYjiOMiMQgfpwXj6uG4NSDtPSAWwTvqbpV7B8iWsXiC8GoMBKg1YsrUxPJhg==
+  dependencies:
+    camel-case "^4.1.2"
+    fast-glob "^3.3.2"
+
 awilix@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/awilix/-/awilix-8.0.1.tgz#4f4704038cc5df3f8f2b9254031af79d4d3708bb"
@@ -6378,7 +6386,7 @@ fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.12, fast-glob@^3.2.9, fast-glob@^3.3.0:
+fast-glob@^3.2.12, fast-glob@^3.2.9, fast-glob@^3.3.0, fast-glob@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
   integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5198,14 +5198,6 @@ autoprefixer@^10.4.16:
     picocolors "^1.0.1"
     postcss-value-parser "^4.2.0"
 
-awilix@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/awilix/-/awilix-11.0.0.tgz#d2b654fd22e43d93ff1dc58285e13d468d04c122"
-  integrity sha512-lnEm2TZu1OUWO1twi/3JrjSYu3RYjiOMiMQgfpwXj6uG4NSDtPSAWwTvqbpV7B8iWsXiC8GoMBKg1YsrUxPJhg==
-  dependencies:
-    camel-case "^4.1.2"
-    fast-glob "^3.3.2"
-
 awilix@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/awilix/-/awilix-8.0.1.tgz#4f4704038cc5df3f8f2b9254031af79d4d3708bb"
@@ -6386,7 +6378,7 @@ fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.12, fast-glob@^3.2.9, fast-glob@^3.3.0, fast-glob@^3.3.2:
+fast-glob@^3.2.12, fast-glob@^3.2.9, fast-glob@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
   integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==


### PR DESCRIPTION
Since the awilix is shared across all the packages including the framework, modules and the medusajs/medusa package, we have to install a single source of it inside the user application.