### PR TITLE
chore: add needed dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,26 +52,32 @@
     "@medusajs/tax": "preview",
     "@medusajs/user": "preview",
     "@medusajs/workflow-engine-inmemory": "preview",
-    "express": "^4.17.2"
+    "express": "^4.17.2",
+    "@mikro-orm/core": "5.9.7",
+    "@mikro-orm/knex": "5.9.7",
+    "@mikro-orm/migrations": "5.9.7",
+    "@mikro-orm/postgresql": "5.9.7",
+    "bignumber.js": "^9.1.2",
+    "ioredis": "^5.4.1",
+    "pg": "^8.13.0",
+    "awilix": "^8.0.1"
   },
   "devDependencies": {
     "@mikro-orm/cli": "5.9.7",
-    "@mikro-orm/core": "5.9.7",
-    "@mikro-orm/migrations": "5.9.7",
-    "@mikro-orm/postgresql": "5.9.7",
     "@stdlib/number-float64-base-normalize": "0.0.8",
     "@swc/core": "1.5.7",
     "@swc/jest": "^0.2.36",
     "@types/express": "^4.17.13",
     "@types/jest": "^29.5.12",
     "@types/mime": "1.3.5",
-    "@types/node": "^17.0.8",
+    "@types/node": "^20.0.0",
     "@types/react": "^18.3.2",
     "jest": "^29.7.0",
     "medusa-test-utils": "preview",
     "prop-types": "^15.8.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.1.6"
+    "typescript": "^5.6.2",
+    "vite": "^5.2.11"
   },
   "resolutions": {
     "**/@medusajs/medusa-cli": "link:./node_modules/@medusajs/medusa-cli"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2170,6 +2170,11 @@
     "@medusajs/modules-sdk" "1.13.0-preview-20240925090259"
     "@medusajs/utils" "1.12.0-preview-20240925090259"
 
+"@medusajs/types@1.12.0-preview-20240925030844":
+  version "1.12.0-preview-20240925030844"
+  resolved "https://registry.yarnpkg.com/@medusajs/types/-/types-1.12.0-preview-20240925030844.tgz#32e786c2797488d17195d56ab0ef501ec687765f"
+  integrity sha512-aszTQnQcAmoauUNiY3b4JbX2vwa5vwOkdAYyP8il7wV2UiFCEWDKfwbxXDyaTp8NbVNKb+75Y9w5PWHZKbTrjw==
+
 "@medusajs/types@1.12.0-preview-20240925090259":
   version "1.12.0-preview-20240925090259"
   resolved "https://registry.yarnpkg.com/@medusajs/types/-/types-1.12.0-preview-20240925090259.tgz#8960855926bc3c2e57fabe4119e809fad669b97e"
@@ -2215,6 +2220,25 @@
   dependencies:
     "@medusajs/utils" "1.12.0-preview-20240925090259"
     jsonwebtoken "^9.0.2"
+
+"@medusajs/utils@1.12.0-preview-20240925030844":
+  version "1.12.0-preview-20240925030844"
+  resolved "https://registry.yarnpkg.com/@medusajs/utils/-/utils-1.12.0-preview-20240925030844.tgz#2dbc4fec2a6ee818d45fdc1544e391c451c97383"
+  integrity sha512-Gowce2fgRLLa8giBOaeySN+6CYTptS5sxX6MN9yHrXntu860MEcuZV+K/8z1ofnCdWtPG386aB3aLoLSTsuu8Q==
+  dependencies:
+    "@medusajs/types" "1.12.0-preview-20240925030844"
+    "@mikro-orm/core" "5.9.7"
+    "@mikro-orm/migrations" "5.9.7"
+    "@mikro-orm/postgresql" "5.9.7"
+    awilix "^8.0.1"
+    bignumber.js "^9.1.2"
+    dotenv "^16.4.5"
+    dotenv-expand "^11.0.6"
+    jsonwebtoken "^9.0.2"
+    pg "^8.13.0"
+    pg-connection-string "^2.7.0"
+    pluralize "^8.0.0"
+    ulid "^2.3.0"
 
 "@medusajs/utils@1.12.0-preview-20240925090259":
   version "1.12.0-preview-20240925090259"
@@ -5231,10 +5255,12 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/node@^17.0.8":
-  version "17.0.45"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
-  integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
+"@types/node@^20.0.0":
+  version "20.16.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.7.tgz#0a245bf5805add998a22b8b5adac612ee70190bc"
+  integrity sha512-QkDQjAY3gkvJNcZOWwzy3BN34RweT0OQ9zJyvLCU0kSK22dO2QYh/NHGfbEAYylPYzRB1/iXcojS79wOg5gFSw==
+  dependencies:
+    undici-types "~6.19.2"
 
 "@types/prismjs@^1.26.0":
   version "1.26.4"
@@ -8601,6 +8627,22 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
+medusa-telemetry@0.0.18-preview-20240925030844:
+  version "0.0.18-preview-20240925030844"
+  resolved "https://registry.yarnpkg.com/medusa-telemetry/-/medusa-telemetry-0.0.18-preview-20240925030844.tgz#159e4e04f639847320898d90b214038acf1228db"
+  integrity sha512-XoWQCs1SX2tJr5a8plIY2kSxEw7SAluYw2YX3msO3ObdS0tm3U7aK7KvTrFeEcvqh10wwT3A2IJiwjbmZZiSRw==
+  dependencies:
+    "@babel/runtime" "^7.22.10"
+    axios "^0.21.4"
+    axios-retry "^3.1.9"
+    boxen "^5.0.1"
+    ci-info "^3.2.0"
+    configstore "5.0.1"
+    global "^4.4.0"
+    is-docker "^2.2.1"
+    remove-trailing-slash "^0.1.1"
+    uuid "^8.3.2"
+
 medusa-telemetry@0.0.18-preview-20240925090259:
   version "0.0.18-preview-20240925090259"
   resolved "https://registry.yarnpkg.com/medusa-telemetry/-/medusa-telemetry-0.0.18-preview-20240925090259.tgz#4c832e6d10f8138165e140e5b72702131d03e01c"
@@ -10564,7 +10606,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^5.1.6:
+typescript@^5.6.2:
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
   integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==


### PR DESCRIPTION
The mentioned dependencies will be needed by the starter once we the packages refactoring will be completed. So adding them now to have them available as our PR gets merged.

Also, existing apps will face errors if they will update dependencies, so we will have to let them know to update their `package.json` files to match the dependencies in the PR