### PR TITLE
chore: fix zod version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "@mikro-orm/migrations": "6.4.3",
     "@mikro-orm/postgresql": "6.4.3",
     "awilix": "^8.0.1",
-    "pg": "^8.13.0"
+    "pg": "^8.13.0",
+    "zod": "3.22.4"
   },
   "devDependencies": {
     "@medusajs/test-utils": "2.5.0",


### PR DESCRIPTION
**What**
In order to prevent multiple version to exists and that might not be compatible with one another, we fix the zod package version in the starter