### PR TITLE
Fix npm install for 2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "devDependencies": {
     "@medusajs/test-utils": "2.6.0",
     "@mikro-orm/cli": "6.4.3",
-    "@swc/core": "1.5.7",
     "@swc/jest": "^0.2.36",
     "@types/jest": "^29.5.13",
     "@types/node": "^20.0.0",


### PR DESCRIPTION
npm install fails with:

```
npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error
npm error While resolving: @medusajs/medusa@2.6.0
npm error Found: @swc/core@1.5.7
npm error node_modules/@swc/core
npm error   dev @swc/core@"1.5.7" from the root project
npm error   peer @swc/core@"*" from @swc/jest@0.2.37
npm error   node_modules/@swc/jest
npm error     dev @swc/jest@"^0.2.36" from the root project
npm error   1 more (ts-node)
npm error
npm error Could not resolve dependency:
npm error peerOptional @swc/core@"^1.7.28" from @medusajs/medusa@2.6.0
npm error node_modules/@medusajs/medusa
npm error   @medusajs/medusa@"2.6.0" from the root project
npm error   peerOptional @medusajs/medusa@"^2.4.0" from @medusajs/test-utils@2.6.0
npm error   node_modules/@medusajs/test-utils
npm error     dev @medusajs/test-utils@"2.6.0" from the root project
npm error
npm error Conflicting peer dependency: @swc/core@1.11.7
npm error node_modules/@swc/core
npm error   peerOptional @swc/core@"^1.7.28" from @medusajs/medusa@2.6.0
npm error   node_modules/@medusajs/medusa
npm error     @medusajs/medusa@"2.6.0" from the root project
npm error     peerOptional @medusajs/medusa@"^2.4.0" from @medusajs/test-utils@2.6.0
npm error     node_modules/@medusajs/test-utils
npm error       dev @medusajs/test-utils@"2.6.0" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /Users/ahmed.kooli/.npm/_logs/2025-03-07T11_14_46_200Z-eresolve-report.txt
```

We should either make the started use: `@swc/core@^1.7.28` instead of `1.5.7` Or remove it altogether, since the started does not use that dep any way (Only uses `swc/jest`)
