### PR TITLE
feat: add npmrc for pnpm support

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+public-hoist-pattern[]=*@medusajs/*
+public-hoist-pattern[]=@tanstack/react-query
+public-hoist-pattern[]=react-i18next
+public-hoist-pattern[]=react-router-dom


### PR DESCRIPTION
Add `.npmrc` to hoist essential packages while developing with Medusa. This is necessary for pnpm support.