### PR TITLE
Wire REDIS_URL env var into projectConfig

### DIFF
--- a/medusa-config.ts
+++ b/medusa-config.ts
@@ -5,6 +5,7 @@ loadEnv(process.env.NODE_ENV || 'development', process.cwd())
 module.exports = defineConfig({
   projectConfig: {
     databaseUrl: process.env.DATABASE_URL,
+    redisUrl: process.env.REDIS_URL,
     http: {
       storeCors: process.env.STORE_CORS!,
       adminCors: process.env.ADMIN_CORS!,


### PR DESCRIPTION
## What

\`.env.template\` already ships \`REDIS_URL=redis://localhost:6379\`, but \`medusa-config.ts\` never read it. Any redis configured via env was silently dropped, forcing users to hand-edit the config file after bootstrapping a new project.

## Change

Add \`redisUrl: process.env.REDIS_URL\` next to \`databaseUrl\` in \`projectConfig\`.

\`\`\`diff
   projectConfig: {
     databaseUrl: process.env.DATABASE_URL,
+    redisUrl: process.env.REDIS_URL,
     http: {
\`\`\`

Falls back to undefined when the var is unset, which matches framework default behavior (no redis configured).

## Related

Fixes medusajs/medusa#14962